### PR TITLE
GA-like API with partial auto-tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+npm-debug.log
+build

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "start-dev": "NODE_ENV=development node ./test/server.js",
     "start": "npm run build && NODE_ENV=production node ./test/server.js"
   },
-  "author": "",
+  "author": "John Babak <babak.john@gmail.com>",
   "license": "",
   "devDependencies": {
+    "body-parser": "^1.13.2",
     "express": "^4.13.1",
     "uglify-js": "^2.4.24"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "c5t-snippet",
+  "version": "0.0.0",
+  "description": "",
+  "scripts": {
+    "build-dev": "rm -r ./build && mkdir -p ./build; ./node_modules/.bin/uglifyjs ./src/c5t.js -o ./build/c5t.js -b",
+    "build": "rm -r ./build && mkdir -p ./build; ./node_modules/.bin/uglifyjs ./src/c5t.js -o ./build/c5t.js -m",
+    "start-dev": "npm run build-dev && node ./test/server.js",
+    "start": "npm run build && node ./test/server.js"
+  },
+  "author": "",
+  "license": "",
+  "devDependencies": {
+    "express": "^4.13.1",
+    "uglify-js": "^2.4.24"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "build-dev": "rm -r ./build && mkdir -p ./build; ./node_modules/.bin/uglifyjs ./src/c5t.js -o ./build/c5t.js -b",
     "build": "rm -r ./build && mkdir -p ./build; ./node_modules/.bin/uglifyjs ./src/c5t.js -o ./build/c5t.js -m",
-    "start-dev": "npm run build-dev && node ./test/server.js",
-    "start": "npm run build && node ./test/server.js"
+    "start-dev": "NODE_ENV=development node ./test/server.js",
+    "start": "npm run build && NODE_ENV=production node ./test/server.js"
   },
   "author": "",
   "license": "",

--- a/src/c5t.js
+++ b/src/c5t.js
@@ -101,7 +101,7 @@
    * @param {Object} [opt_fieldObject] The `fieldObject` overrides for this particular hit.
    */
   TrackerProto[str_send] = function (hitType, opt_fieldObject) {
-    _DEBUG_log(c5t_name, str_send, this[_trackerDataPropertyName], arguments);
+    _DEBUG_log(c5t_name, str_send, this[_trackerDataPropertyName], hitType, opt_fieldObject);
   };
   
   /**

--- a/src/c5t.js
+++ b/src/c5t.js
@@ -1,0 +1,183 @@
+(function (window) {
+  var str_call = "call";
+  var str_apply = "apply";
+  var str_indexOf = "indexOf";
+  var str_prototype = "prototype";
+  var str_shift = "shift";
+  var str_create = "create";
+  var str_send = "send";
+  var str_set = "set";
+  var str_get = "get";
+  var str_trackingId = "trackingId";
+  var str_cookieDomain = "cookieDomain";
+  var str_name = "name";
+  
+  var _defaultTrackerName = "";
+  var _trackerDataPropertyName = "d";
+  
+  var _hasOwnProperty = {}.hasOwnProperty;
+  var _toArray = [].slice;
+  
+  var _primitiveTypes = [
+    "number",
+    "string",
+    "object",
+    "boolean"
+  ];
+  
+  // A collection of trackers by name.
+  var _trackersByName = {};
+  
+  // Get everything from the stub object that will be replaced.
+  var c5t_name = (window.CurrentIntelligenceObject || "c5t");
+  var c5t = ((_isString(c5t_name) && window[c5t_name]) || {});
+  var c5t_queue = (c5t.q || []);
+  var c5t_snippetTime = (c5t.l || 1*new Date());
+  
+  function _DEBUG_log() {
+    try {
+      console && console.log && console.log.apply(console, arguments);
+    }
+    catch (ex) {}
+  }
+  
+ /**
+  * Checks if the passed in value is a string.
+  *
+  * @param {*} value The value to check.
+  * @returns {boolean}
+  */
+  function _isString(value) {
+    return (void 0 != value && -1 < (value.constructor+"")[str_indexOf]("String"));
+  }
+  
+  /**
+   * Checks if the passed in value is of a primitive data type (e.g. a 'number' or a 'boolean').
+   *
+   * @param {*} value The value to check.
+   * @returns {boolean}
+   */
+  function _isPrimitiveType(value) {
+    return (-1 < _primitiveTypes.indexOf(typeof value));
+  }
+  
+  /**
+   * Shallow extend of one object with another.
+   * Does not propagate non-primitive data types to the destination.
+   *
+   * @param {Object} dst The destination object.
+   * @param {Object} [src] The source object.
+   * @returns {Object} The destinatin object.
+   */
+  function _extendPrimitive(dst, src) {
+    if (src) {
+      for (var x in src) {
+        if (_hasOwnProperty[str_call](src, x) && _isPrimitiveType(src[x])) {
+          dst[x] = src[x];
+        }
+      }
+    }
+    return dst;
+  }
+  
+  /**
+   * The tracker constructor.
+   *
+   * @param {Object} [data] The tracker initial data.
+   */
+  function Tracker(data) {
+    this[_trackerDataPropertyName] = _extendPrimitive({}, data);
+    
+    _DEBUG_log(c5t_name, str_create, this[_trackerDataPropertyName]);
+  }
+  
+  var TrackerProto = Tracker[str_prototype];
+  
+  /**
+   * @param {string} hitType Hit type (e.g. 'event').
+   * @param {Object} [opt_fieldObject] The `fieldObject` overrides for this particular hit.
+   */
+  TrackerProto[str_send] = function (hitType, opt_fieldObject) {
+    _DEBUG_log(c5t_name, str_send, this[_trackerDataPropertyName], arguments);
+  };
+  
+  /**
+   * Sets a property on the tracker.
+   *
+   * @param {string|Object} arg0 Either `fieldName` or `fieldObject` (and no arguments after it).
+   * @param {string} [arg1] Either `fieldValue` for the `fieldName` or nothing.
+   */
+  TrackerProto[str_set] = function () {
+    var args = _toArray[str_call](arguments);
+    var data = this[_trackerDataPropertyName];
+    if (_isString(args[0])) {
+      data[args[0]] = args[1];
+    }
+    else {
+      _extendPrimitive(data, args[0]);
+    }
+  };
+  
+  /**
+   * Gets a property on the tracker.
+   *
+   * @param {string} fieldName The `fieldName`.
+   */
+  TrackerProto[str_get] = function (fieldName) {
+    return this[_trackerDataPropertyName][fieldName];
+  };
+  
+  /**
+   * Creates a tracker.
+   *
+   * @param {string|Object} arg0 Either `trackingId` or `opt_configObject` (and no arguments after it).
+   * @param {string|Object} [arg1] Either `cookieDomain` or `opt_configObject` (and no arguments after it).
+   * @param {Object} [arg2] The `opt_configObject`.
+   */
+  function _create() {
+    var args = _toArray[str_call](arguments);
+    var data = {};
+    if (_isString(args[0])) {
+      data[str_trackingId] = args[str_shift]();
+    }
+    if (_isString(args[0])) {
+      data[str_cookieDomain] = args[str_shift]();
+    }
+    _extendPrimitive(data, args[0]);
+    return (_trackersByName[data[str_name] || _defaultTrackerName] = new Tracker(data));
+  }
+  
+  /**
+   * Calls a library or tracker method.
+   *
+   * @param {Arguments} args The arguments to call the method with.
+   * @returns {*} The return value of the called method.
+   */
+  function _call(args) {
+    args = _toArray[str_call](args);
+    var fnName = args[str_shift]();
+    if (fnName === str_create) {
+      return _create[str_apply](null, args);
+    }
+    var tracker = _trackersByName[_defaultTrackerName];
+    if (tracker) {
+      var fn = tracker[fnName];
+      if (fn && fn[str_apply]) {
+        return fn[str_apply](tracker, args);
+      }
+    }
+  }
+  
+  // Replace with the function that makes immediate calls.
+  c5t = window[c5t_name] = function () {
+    return _call(arguments);
+  };
+  
+  // Put the library methods on the `c5t` object itself.
+  c5t[str_create] = _create;
+  
+  // Execute the queued calls.
+  while (c5t_queue.length > 0) {
+    _call(c5t_queue[str_shift]());
+  }
+}(window));

--- a/src/c5t.js
+++ b/src/c5t.js
@@ -1,4 +1,6 @@
 (function (window, document, navigator) {
+  'use strict';
+  
   var str_call = "call";
   var str_apply = "apply";
   var str_indexOf = "indexOf";
@@ -247,7 +249,7 @@
     }
     _extend(data, args[0], _isPrimitiveType);
     var trackerName = (data[str_name] || _defaultTrackerName);
-    tracker = (_trackersByName[trackerName] || new Tracker());
+    var tracker = (_trackersByName[trackerName] || new Tracker());
     tracker.set(data);
     if (!_trackersByName[trackerName]) {
       _trackersByName[trackerName] = tracker;
@@ -368,10 +370,14 @@
   }
   
   function _onWindowUnload() {
-    tracker.send('event', {
-      'eventCategory': 'c5t.io',
-      'eventAction': 'Exit',
-      'transport': 'beacon'
+    _forEachTracker(function (tracker) {
+      if (tracker.get(str_trackEnterExit)) {
+        tracker.send('event', {
+          'eventCategory': 'c5t.io',
+          'eventAction': 'Exit',
+          'transport': 'beacon'
+        });
+      }
     });
   }
   

--- a/src/c5t.js
+++ b/src/c5t.js
@@ -1,6 +1,4 @@
-(function (window) {
-  var document = window.document;
-  
+(function (window, document) {
   var str_call = "call";
   var str_apply = "apply";
   var str_indexOf = "indexOf";
@@ -220,4 +218,4 @@
     document[str_addEventListener] && document[str_addEventListener](visibilityChangeEvent, _onVisibilityChange);
     _onVisibilityChange();
   }
-}(window));
+}(window, document));

--- a/test/index.html
+++ b/test/index.html
@@ -15,8 +15,8 @@ c5t('set', {
   'title': 'Test'
 });
 c5t('send', 'event', {
-  'eventCategory': 'Category',
-  'eventAction': 'Action'
+  'eventCategory': 'Test Category',
+  'eventAction': 'Test Action'
 });
 </script>
 </head>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+<title></title>
+<script>
+(function(c,ur,re,nt,_,i,o){c['CurrentIntelligenceObject']=_;c[_]=c[_]||function(){
+(c[_].q=c[_].q||[]).push(arguments)},c[_].l=1*new Date();i=ur.createElement(re),
+o=ur.getElementsByTagName(re)[0];i.async=1;i.src=nt;o.parentNode.insertBefore(i,o)
+})(window,document,'script','//localhost:3000/c5t.js','c5t');
+
+c5t('create', 'API_KEY');
+c5t('set', 'page', '/');
+c5t('set', {
+  'page': '/test',
+  'title': 'Test'
+});
+c5t('send', 'event', {
+  'eventCategory': 'Category',
+  'eventAction': 'Action'
+});
+</script>
+</head>
+<body>
+<p>See the DevTools console for details.</p>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -9,15 +9,15 @@ o=ur.getElementsByTagName(re)[0];i.async=1;i.src=nt;o.parentNode.insertBefore(i,
 })(window,document,'script','//localhost:3000/c5t.js','c5t');
 
 c5t('create', 'API_KEY');
-c5t('set', 'page', '/');
-c5t('set', {
-  'page': '/test',
-  'title': 'Test'
-});
-c5t('send', 'event', {
-  'eventCategory': 'Test Category',
-  'eventAction': 'Test Action'
-});
+c5t('set', 'trackEnterExit', true);
+c5t('set', 'trackForegroundBackground', true);
+
+setTimeout(function () {
+  c5t('send', 'event', {
+    'eventCategory': 'Test Category',
+    'eventAction': 'Test Action'
+  });
+}, 3000);
 </script>
 </head>
 <body>

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
 o=ur.getElementsByTagName(re)[0];i.async=1;i.src=nt;o.parentNode.insertBefore(i,o)
 })(window,document,'script','//localhost:3000/c5t.js','c5t');
 
-c5t('create', 'API_KEY');
+c5t('create', 'ACCOUNT_ID');
 c5t('set', 'trackEnterExit', true);
 c5t('set', 'trackForegroundBackground', true);
 

--- a/test/server.js
+++ b/test/server.js
@@ -2,11 +2,12 @@ var fs_ = require('fs');
 var path_ = require('path');
 var express_ = require('express');
 
-var app = express_();
 
-app.set('x-powered-by', false);
+var testApp = express_();
 
-app.get('/', function (req, res) {
+testApp.set('x-powered-by', false);
+
+testApp.get('/', function (req, res) {
   res.format({
     'text/html': function () {
       res.set('Content-Type', 'text/html');
@@ -19,7 +20,7 @@ app.get('/', function (req, res) {
   });
 });
 
-app.get('/c5t.js', function (req, res) {
+testApp.get('/c5t.js', function (req, res) {
   res.format({
     'text/javascript': function () {
       res.set('Content-Type', 'text/javascript');
@@ -33,6 +34,31 @@ app.get('/c5t.js', function (req, res) {
   });
 });
 
-var server = app.listen(3000, function () {
-  console.log('Listening at http://localhost:%s', server.address().port);
+var testServer = testApp.listen(3000, function () {
+  console.log('Test server listening at http://localhost:%s', testServer.address().port);
+});
+
+
+// Establish a separate server for logging to test different origins.
+var loggingApp = express_();
+
+loggingApp.set('x-powered-by', false);
+
+loggingApp.use(require('body-parser').urlencoded({
+  extended: false,
+  type: function () { return true; }
+}));
+
+loggingApp.all('/log/:trackingId', function (req, res) {
+  console.log(
+    '\n[' + (1*new Date()) + '] ' +
+    req.method + ' ' + req.url + '\n' +
+    req.params.trackingId + ' ' +
+    JSON.stringify((req.method === 'GET' ? req.query : req.body), true, 2)
+  );
+  res.status(200).end();
+});
+
+var loggingServer = loggingApp.listen(4000, function () {
+  console.log('Logging server listening at http://localhost:%s', loggingServer.address().port);
 });

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,37 @@
+var fs_ = require('fs');
+var path_ = require('path');
+var express_ = require('express');
+
+var app = express_();
+
+app.set('x-powered-by', false);
+
+app.get('/', function (req, res) {
+  res.format({
+    'text/html': function () {
+      res.set('Content-Type', 'text/html');
+      res.end(fs_.readFileSync(path_.join(__dirname, 'index.html')));
+    },
+    
+    'default': function () {
+      res.status(406).end('Not Acceptable');
+    }
+  });
+});
+
+app.get('/c5t.js', function (req, res) {
+  res.format({
+    'text/javascript': function () {
+      res.set('Content-Type', 'text/javascript');
+      res.end(fs_.readFileSync(path_.join(path_.resolve(__dirname, '..', 'build'), 'c5t.js')));
+    },
+    
+    'default': function () {
+      res.status(406).end('Not Acceptable');
+    }
+  });
+});
+
+var server = app.listen(3000, function () {
+  console.log('Listening at http://localhost:%s', server.address().port);
+});

--- a/test/server.js
+++ b/test/server.js
@@ -23,7 +23,8 @@ app.get('/c5t.js', function (req, res) {
   res.format({
     'text/javascript': function () {
       res.set('Content-Type', 'text/javascript');
-      res.end(fs_.readFileSync(path_.join(path_.resolve(__dirname, '..', 'build'), 'c5t.js')));
+      res.end(fs_.readFileSync(path_.join(path_.resolve(__dirname, '..', 
+        (process.env.NODE_ENV === 'development' ? 'src' : 'build')), 'c5t.js')));
     },
     
     'default': function () {


### PR DESCRIPTION
- The API mimicks the Google Analytics API:
  https://developers.google.com/analytics/devguides/collection/analyticsjs/#quickstart
  https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference#top_of_page
- The custom events work exactly like in GA (`c5t('send', 'event', { 'eventCategory': '...', 'eventAction': '...' })`).
- The 'Foreground' (user switched to the page) and 'Background' (user switched away without navigating away) events are tracked automatically via the [Page Visibility API](http://caniuse.com/#feat=pagevisibility) and sent if the corresponding `trackForegroundBackground` flag is set on the tracker.
- The 'Enter' (user first loads the page) event is tracked automatically on first load of the script and sent if the corresponding `trackEnterExit` flag is set.
- The actual sending to the backend is implemented via three different transports: `xhr` (XMLHttpRequest, POST), `image` (Image, GET), `beacon` (sendBeacon, POST). A simple test backend that accepts the events is implemented in JavaScript (Node.js). The transport can be configured per each `send` call (compatible with [GA API transport and useBeacon](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport)).
- The 'Exit' event (user navigates from the page) is implemented via the window `unload` event and the `beacon` transport if it's available (if it's not, another transport is chosen automatically based on the payload size).
- The [Client ID](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#clientId) is not yet implemented. TODO.
